### PR TITLE
docs: add AGENTS workflow caching rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,5 +8,6 @@ All agents must follow these rules:
    - Support titles: `fix(docs):`, `fix(benchmarks):`, `fix(cicd):`
 3) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
 4) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
+5) Maximize the use of caching in GitHub workflow files to minimize run duration.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
## Summary
- Add the caching rule.

## Rationale
- Reduce CI run time / keep guidance consistent.

## Details
- Update AGENTS.md only.
