### PR TITLE
docs: require Conventional Commits with user value

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,5 +9,6 @@ All agents must follow these rules:
 3) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
 4) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
 5) Maximize the use of caching in GitHub workflow files to minimize run duration.
+6) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary
- Add commit message guidance to `AGENTS.md` that requires Conventional Commits prefixes and user-value callouts.

Rationale
- Consistent commit messages make history easier to scan and improve user-facing release notes.

Details
- Add the rule requiring Conventional Commits prefixes plus a short functional description and user-facing value proposition.