### PR TITLE
test: centralize pytest config in pytest.ini

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-
 .PHONY: docs
 
 test:
-	pytest tests --cov generic_exporters --cov-report term-missing -s
+	pytest
 
 docs:
 	rm -r ./docs/source -f

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --cov generic_exporters --cov-report term-missing -s
+testpaths = tests


### PR DESCRIPTION
## Summary
- Add `pytest.ini` with centralized pytest options
- Simplify the Makefile test target to plain `pytest`

## Rationale
- Centralized pytest config avoids drift and keeps local and CI runs consistent.

## Details
- `pytest.ini`
- `Makefile`

## Testing
- Command(s) run: none (skipped per user instruction)
- Result: SKIPPED
